### PR TITLE
remove annyoing extra space

### DIFF
--- a/basheditor-plugin/src/main/java-eclipse/de/jcup/basheditor/BashBracketInsertionCompleter.java
+++ b/basheditor-plugin/src/main/java-eclipse/de/jcup/basheditor/BashBracketInsertionCompleter.java
@@ -96,8 +96,8 @@ class BashBracketInsertionCompleter extends KeyAdapter {
 		@Override
 		protected void insertClosingBrackets(IDocument document, ISelectionProvider selectionProvider, int offset)
 				throws BadLocationException {
-			document.replace(offset - 1, 1, "[ ]");
-			selectionProvider.setSelection(new TextSelection(offset + 1, 0));
+			document.replace(offset - 1, 1, "[]");
+			selectionProvider.setSelection(new TextSelection(offset, 0));
 
 		}
 
@@ -108,8 +108,8 @@ class BashBracketInsertionCompleter extends KeyAdapter {
 		@Override
 		protected void insertClosingBrackets(IDocument document, ISelectionProvider selectionProvider, int offset)
 				throws BadLocationException {
-			document.replace(offset - 1, 1, "{ }");
-			selectionProvider.setSelection(new TextSelection(offset + 1, 0));
+			document.replace(offset - 1, 1, "{}");
+			selectionProvider.setSelection(new TextSelection(offset, 0));
 
 		}
 


### PR DESCRIPTION
Currently when auto-bracket completion is turned on and you try to type expansion of bash variables like

  echo "${myARRAY[index]}"

you get 2 extra spaces when you type the opening curly and square brackets.
That's really annoying. This PR removes those spaces.