### PR TITLE
Feature 117

### DIFF
--- a/basheditor-plugin/src/main/java-eclipse/de/jcup/basheditor/BashEditor.java
+++ b/basheditor-plugin/src/main/java-eclipse/de/jcup/basheditor/BashEditor.java
@@ -21,7 +21,6 @@ import static de.jcup.basheditor.preferences.BashEditorPreferenceConstants.P_EDI
 import static de.jcup.basheditor.preferences.BashEditorPreferenceConstants.P_EDITOR_MATCHING_BRACKETS_ENABLED;
 import static de.jcup.basheditor.preferences.BashEditorPreferenceConstants.P_SAVE_ACTION_EXTERNAL_TOOL_ENABLED;
 import static de.jcup.basheditor.preferences.BashEditorPreferenceConstants.P_SAVE_ACTION_EXTERNAL_TOOL_COMMAND;
-import static de.jcup.basheditor.preferences.BashEditorPreferenceConstants.P_SAVE_ACTION_EXTERNAL_TOOL_ARGUMENTS;
 import static de.jcup.basheditor.preferences.BashEditorValidationPreferenceConstants.VALIDATE_BLOCK_STATEMENTS;
 import static de.jcup.basheditor.preferences.BashEditorValidationPreferenceConstants.VALIDATE_DO_STATEMENTS;
 import static de.jcup.basheditor.preferences.BashEditorValidationPreferenceConstants.VALIDATE_ERROR_LEVEL;
@@ -791,16 +790,11 @@ public class BashEditor extends TextEditor implements StatusMessageSupport, IRes
 	private void callExternalToolAndRefreshEditorContent(IProgressMonitor progressMonitor) throws CoreException {
 		// we will run the external tool from the directory where the current file is
 		// located:
-		String externalToolCmd = getPreferences().getStringPreference(P_SAVE_ACTION_EXTERNAL_TOOL_COMMAND);
-		if (externalToolCmd == null || externalToolCmd.trim().isEmpty()) {
-			return;
-		}
-		String externalToolArguments = getPreferences().getStringPreference(P_SAVE_ACTION_EXTERNAL_TOOL_ARGUMENTS);
-		if (externalToolArguments == null || externalToolArguments.trim().isEmpty()) {
+		String externalToolString = getPreferences().getStringPreference(P_SAVE_ACTION_EXTERNAL_TOOL_COMMAND);
+		if (externalToolString == null || externalToolString.trim().isEmpty()) {
 			return;
 		}
 		
-		String externalToolString = externalToolCmd + " " + externalToolArguments;
 		if (progressMonitor != null) {
 			progressMonitor.beginTask(externalToolString, 1);
 		}

--- a/basheditor-plugin/src/main/java-eclipse/de/jcup/basheditor/BashEditor.java
+++ b/basheditor-plugin/src/main/java-eclipse/de/jcup/basheditor/BashEditor.java
@@ -843,10 +843,10 @@ public class BashEditor extends TextEditor implements StatusMessageSupport, IRes
 				file.refreshLocal(IResource.DEPTH_ZERO, progressMonitor);
 			} else {
 				throw new CoreException(new Status(Status.ERROR, BashEditorActivator.PLUGIN_ID,
-						"Execution of '" + externalToolString + "' failed with exit code " + exitCode + ": " + OutputHandler.STRING_OUTPUT.getFullOutput()));
+						"External re-formatting tool '" + externalToolString + "' failed with exit code " + exitCode + ": " + OutputHandler.STRING_OUTPUT.getFullOutput()));
 			}
 		} catch (IOException e) {
-			throw new CoreException(new Status(Status.ERROR, BashEditorActivator.PLUGIN_ID, "Failed running external tool '" + externalToolString + "'", e));
+			throw new CoreException(new Status(Status.ERROR, BashEditorActivator.PLUGIN_ID, "Failed running external re-formatting tool '" + externalToolString + "'", e));
 		}
 	}
 

--- a/basheditor-plugin/src/main/java-eclipse/de/jcup/basheditor/BashEditor.java
+++ b/basheditor-plugin/src/main/java-eclipse/de/jcup/basheditor/BashEditor.java
@@ -21,6 +21,7 @@ import static de.jcup.basheditor.preferences.BashEditorPreferenceConstants.P_EDI
 import static de.jcup.basheditor.preferences.BashEditorPreferenceConstants.P_EDITOR_MATCHING_BRACKETS_ENABLED;
 import static de.jcup.basheditor.preferences.BashEditorPreferenceConstants.P_SAVE_ACTION_EXTERNAL_TOOL_ENABLED;
 import static de.jcup.basheditor.preferences.BashEditorPreferenceConstants.P_SAVE_ACTION_EXTERNAL_TOOL_COMMAND;
+import static de.jcup.basheditor.preferences.BashEditorPreferenceConstants.P_SAVE_ACTION_EXTERNAL_TOOL_ARGUMENTS;
 import static de.jcup.basheditor.preferences.BashEditorValidationPreferenceConstants.VALIDATE_BLOCK_STATEMENTS;
 import static de.jcup.basheditor.preferences.BashEditorValidationPreferenceConstants.VALIDATE_DO_STATEMENTS;
 import static de.jcup.basheditor.preferences.BashEditorValidationPreferenceConstants.VALIDATE_ERROR_LEVEL;
@@ -89,6 +90,7 @@ import de.jcup.basheditor.outline.BashEditorContentOutlinePage;
 import de.jcup.basheditor.outline.BashEditorTreeContentProvider;
 import de.jcup.basheditor.outline.BashQuickOutlineDialog;
 import de.jcup.basheditor.outline.Item;
+import de.jcup.basheditor.preferences.BashEditorPreferenceConstants;
 import de.jcup.basheditor.preferences.BashEditorPreferences;
 import de.jcup.basheditor.process.BashEditorFileProcessContext;
 import de.jcup.basheditor.process.CancelStateProvider;
@@ -789,10 +791,16 @@ public class BashEditor extends TextEditor implements StatusMessageSupport, IRes
 	private void callExternalToolAndRefreshEditorContent(IProgressMonitor progressMonitor) throws CoreException {
 		// we will run the external tool from the directory where the current file is
 		// located:
-		String externalToolString = getPreferences().getStringPreference(P_SAVE_ACTION_EXTERNAL_TOOL_COMMAND);
-		if (externalToolString == null || externalToolString.trim().isEmpty()) {
+		String externalToolCmd = getPreferences().getStringPreference(P_SAVE_ACTION_EXTERNAL_TOOL_COMMAND);
+		if (externalToolCmd == null || externalToolCmd.trim().isEmpty()) {
 			return;
 		}
+		String externalToolArguments = getPreferences().getStringPreference(P_SAVE_ACTION_EXTERNAL_TOOL_ARGUMENTS);
+		if (externalToolArguments == null || externalToolArguments.trim().isEmpty()) {
+			return;
+		}
+		
+		String externalToolString = externalToolCmd + " " + externalToolArguments;
 		if (progressMonitor != null) {
 			progressMonitor.beginTask(externalToolString, 1);
 		}
@@ -817,7 +825,8 @@ public class BashEditor extends TextEditor implements StatusMessageSupport, IRes
 			// substitute in the external tool cmd line the special placeholders:
 			String[] cmd_args = commandArrayBuilder.build(externalToolString, bashFile);
 
-			SimpleProcessExecutor executor = new SimpleProcessExecutor(OutputHandler.STRING_OUTPUT, false, EXTERNAL_TOOL_TIMEOUT_ON_SAVE_SECS);
+			OutputHandler.STRING_OUTPUT.clearOutput();
+			SimpleProcessExecutor executor = new SimpleProcessExecutor(OutputHandler.STRING_OUTPUT, true, true, EXTERNAL_TOOL_TIMEOUT_ON_SAVE_SECS);
 
 			/* handle potential cancel operation */
 			if (progressMonitor != null) {

--- a/basheditor-plugin/src/main/java-eclipse/de/jcup/basheditor/BashEditor.java
+++ b/basheditor-plugin/src/main/java-eclipse/de/jcup/basheditor/BashEditor.java
@@ -843,10 +843,10 @@ public class BashEditor extends TextEditor implements StatusMessageSupport, IRes
 				file.refreshLocal(IResource.DEPTH_ZERO, progressMonitor);
 			} else {
 				throw new CoreException(new Status(Status.ERROR, BashEditorActivator.PLUGIN_ID,
-						"External re-formatting tool '" + externalToolString + "' failed with exit code " + exitCode + ": " + OutputHandler.STRING_OUTPUT.getFullOutput()));
+						"Execution of '" + externalToolString + "' failed with exit code " + exitCode + ": " + OutputHandler.STRING_OUTPUT.getFullOutput()));
 			}
 		} catch (IOException e) {
-			throw new CoreException(new Status(Status.ERROR, BashEditorActivator.PLUGIN_ID, "Failed running external re-formatting tool '" + externalToolString + "'", e));
+			throw new CoreException(new Status(Status.ERROR, BashEditorActivator.PLUGIN_ID, "Failed running external tool '" + externalToolString + "'", e));
 		}
 	}
 

--- a/basheditor-plugin/src/main/java-eclipse/de/jcup/basheditor/preferences/BashEditorPreferenceConstants.java
+++ b/basheditor-plugin/src/main/java-eclipse/de/jcup/basheditor/preferences/BashEditorPreferenceConstants.java
@@ -33,8 +33,7 @@ public enum BashEditorPreferenceConstants implements PreferenceIdentifiable {
 	P_TOOLTIPS_ENABLED("toolTipsEnabled"),
 
 	P_SAVE_ACTION_EXTERNAL_TOOL_ENABLED("saveActionExternalToolEnabled"),
-	P_SAVE_ACTION_EXTERNAL_TOOL_COMMAND("saveActionExternalToolCommand"),
-	P_SAVE_ACTION_EXTERNAL_TOOL_ARGUMENTS("saveActionExternalToolArguments");
+	P_SAVE_ACTION_EXTERNAL_TOOL_COMMAND("saveActionExternalToolCommand");
 
 	private String id;
 

--- a/basheditor-plugin/src/main/java-eclipse/de/jcup/basheditor/preferences/BashEditorPreferenceConstants.java
+++ b/basheditor-plugin/src/main/java-eclipse/de/jcup/basheditor/preferences/BashEditorPreferenceConstants.java
@@ -33,7 +33,8 @@ public enum BashEditorPreferenceConstants implements PreferenceIdentifiable {
 	P_TOOLTIPS_ENABLED("toolTipsEnabled"),
 
 	P_SAVE_ACTION_EXTERNAL_TOOL_ENABLED("saveActionExternalToolEnabled"),
-	P_SAVE_ACTION_EXTERNAL_TOOL_COMMAND("saveActionExternalToolCommand"),;
+	P_SAVE_ACTION_EXTERNAL_TOOL_COMMAND("saveActionExternalToolCommand"),
+	P_SAVE_ACTION_EXTERNAL_TOOL_ARGUMENTS("saveActionExternalToolArguments");
 
 	private String id;
 

--- a/basheditor-plugin/src/main/java-eclipse/de/jcup/basheditor/preferences/BashEditorPreferenceInitializer.java
+++ b/basheditor-plugin/src/main/java-eclipse/de/jcup/basheditor/preferences/BashEditorPreferenceInitializer.java
@@ -93,8 +93,8 @@ public class BashEditorPreferenceInitializer extends AbstractPreferenceInitializ
 		/* ++++++++++++++ */
 		store.setDefault(P_SAVE_ACTION_EXTERNAL_TOOL_ENABLED.getId(),false);
 		// we use "beautysh -f $filename" as default - see https://github.com/bemeurer/beautysh for installation
-		store.setDefault(P_SAVE_ACTION_EXTERNAL_TOOL_COMMAND.getId(),"/usr/local/bin/beautysh"); 
-		store.setDefault(P_SAVE_ACTION_EXTERNAL_TOOL_ARGUMENTS.getId(),"-f $filename"); 
+		store.setDefault(P_SAVE_ACTION_EXTERNAL_TOOL_COMMAND.getId(),"beautysh -f $filename"); 
+
 	}
 
 }

--- a/basheditor-plugin/src/main/java-eclipse/de/jcup/basheditor/preferences/BashEditorPreferenceInitializer.java
+++ b/basheditor-plugin/src/main/java-eclipse/de/jcup/basheditor/preferences/BashEditorPreferenceInitializer.java
@@ -93,7 +93,8 @@ public class BashEditorPreferenceInitializer extends AbstractPreferenceInitializ
 		/* ++++++++++++++ */
 		store.setDefault(P_SAVE_ACTION_EXTERNAL_TOOL_ENABLED.getId(),false);
 		// we use "beautysh -f $filename" as default - see https://github.com/bemeurer/beautysh for installation
-		store.setDefault(P_SAVE_ACTION_EXTERNAL_TOOL_COMMAND.getId(),"beautysh -f $filename"); 
+		store.setDefault(P_SAVE_ACTION_EXTERNAL_TOOL_COMMAND.getId(),"/usr/local/bin/beautysh"); 
+		store.setDefault(P_SAVE_ACTION_EXTERNAL_TOOL_ARGUMENTS.getId(),"-f $filename"); 
 	}
 
 }

--- a/basheditor-plugin/src/main/java-eclipse/de/jcup/basheditor/preferences/BashEditorSaveActionsPreferencePage.java
+++ b/basheditor-plugin/src/main/java-eclipse/de/jcup/basheditor/preferences/BashEditorSaveActionsPreferencePage.java
@@ -48,11 +48,6 @@ public class BashEditorSaveActionsPreferencePage extends FieldEditorPreferencePa
 	@Override
 	protected void createFieldEditors() {
 		
-		Composite appearanceComposite = new Composite(getFieldEditorParent(), SWT.NONE);
-		GridLayout layout = new GridLayout();
-		layout.numColumns = 2;
-		appearanceComposite.setLayout(layout);
-		
 		/* --------------------- */
 		/* --   Save action   -- */
 		/* --------------------- */
@@ -61,7 +56,7 @@ public class BashEditorSaveActionsPreferencePage extends FieldEditorPreferencePa
 		externalToolsGroupLayoutData.horizontalSpan = 2;
 		externalToolsGroupLayoutData.widthHint = 400;
 
-		Group externalToolGroup = new Group(appearanceComposite, SWT.NONE);
+		Group externalToolGroup = new Group(getFieldEditorParent(), SWT.NONE);
 		externalToolGroup.setText("External tool");
 		externalToolGroup.setLayout(new GridLayout());
 		externalToolGroup.setLayoutData(externalToolsGroupLayoutData);

--- a/basheditor-plugin/src/main/java-eclipse/de/jcup/basheditor/preferences/BashEditorSaveActionsPreferencePage.java
+++ b/basheditor-plugin/src/main/java-eclipse/de/jcup/basheditor/preferences/BashEditorSaveActionsPreferencePage.java
@@ -17,11 +17,15 @@ package de.jcup.basheditor.preferences;
 
 import static de.jcup.basheditor.preferences.BashEditorPreferenceConstants.P_SAVE_ACTION_EXTERNAL_TOOL_COMMAND;
 import static de.jcup.basheditor.preferences.BashEditorPreferenceConstants.P_SAVE_ACTION_EXTERNAL_TOOL_ENABLED;
-import static de.jcup.basheditor.preferences.BashEditorPreferenceConstants.P_SAVE_ACTION_EXTERNAL_TOOL_ARGUMENTS;
+import static org.eclipse.swt.events.SelectionListener.widgetSelectedAdapter;
 
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+
+import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.preference.BooleanFieldEditor;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
-import org.eclipse.jface.preference.FileFieldEditor;
 import org.eclipse.jface.preference.StringFieldEditor;
 import org.eclipse.jface.util.PropertyChangeEvent;
 import org.eclipse.swt.SWT;
@@ -34,30 +38,21 @@ import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
 
 import de.jcup.basheditor.BashEditorUtil;
+import de.jcup.basheditor.ExternalToolCommandArrayBuilder;
+import de.jcup.basheditor.process.BashEditorFileProcessContext;
+import de.jcup.basheditor.process.OutputHandler;
+import de.jcup.basheditor.process.SimpleProcessExecutor;
 
 public class BashEditorSaveActionsPreferencePage extends FieldEditorPreferencePage implements IWorkbenchPreferencePage {
-	private BooleanFieldEditor saveActionExternalSourceFormatterEnabled;
-	private MyFileEditor saveActionExternalSourceFormatter;
-	private StringFieldEditor saveActionExternalSourceFormatterArguments;
-	
 	// UI
-	private Composite fileComposite;
+	private BooleanFieldEditor saveActionExternalSourceFormatterEnabled;
+	private StringFieldEditor saveActionExternalSourceFormatterArguments;
 	private Group externalToolGroup;
+	private Button validateBtn;
 	
-	// dummy class just to override the FileFieldEditor::getChangeControl() visibility:
-	class MyFileEditor extends FileFieldEditor {
-		public MyFileEditor(String name, String labelText, Composite parent) {
-			super(name, labelText, parent);
-		}
+	// non-UI
+	private ExternalToolCommandArrayBuilder commandArrayBuilder = new ExternalToolCommandArrayBuilder();
 
-		@Override
-		public Button getChangeControl(Composite parent) {
-			return super.getChangeControl(parent);
-		}
-	}
-
-	
-	
 	public BashEditorSaveActionsPreferencePage() {
 		super(GRID);
 		setPreferenceStore(BashEditorUtil.getPreferences().getPreferenceStore());
@@ -91,22 +86,12 @@ public class BashEditorSaveActionsPreferencePage extends FieldEditorPreferencePa
 			setToolTipText("External program to run every time a script file is saved; its output will replace current document.");
 		addField(saveActionExternalSourceFormatterEnabled);
 
-		// NOTE: we create a Composite in which we place the FileFieldEditor() and set an horizontalSpan = 2, so will take the entire second row of grid 
-		fileComposite = new Composite(externalToolGroup, SWT.NONE);
-		fileComposite.setLayout(new GridLayout(1, false));
-		GridData fileLayoutData = new GridData(GridData.HORIZONTAL_ALIGN_FILL|GridData.GRAB_HORIZONTAL);
-		fileLayoutData.horizontalSpan = 2;
-		fileComposite.setLayoutData(fileLayoutData);
-		saveActionExternalSourceFormatter = 
-				new MyFileEditor(P_SAVE_ACTION_EXTERNAL_TOOL_COMMAND.getId(), "External tool", fileComposite);
-		addField(saveActionExternalSourceFormatter);
-		
-		// NOTE: the StringFieldEditor() has an horizontal span = 2, so will take the entire third row of grid
+		// NOTE: the StringFieldEditor() has an horizontal span = 2, so will take the entire second row of grid
 		saveActionExternalSourceFormatterArguments = 
-				new StringFieldEditor(P_SAVE_ACTION_EXTERNAL_TOOL_ARGUMENTS.getId(), "External tool command-line arguments:", 
+				new StringFieldEditor(P_SAVE_ACTION_EXTERNAL_TOOL_COMMAND.getId(), "External tool command-line:", 
 						StringFieldEditor.UNLIMITED, StringFieldEditor.VALIDATE_ON_FOCUS_LOST, externalToolGroup);
 		addField(saveActionExternalSourceFormatterArguments);
-
+		
 		// NOTE: we create a Composite in which we place the note fields and set an horizontalSpan = 2, so will take the entire last row of grid
 		Composite labelComposite = new Composite(externalToolGroup, SWT.NONE);
 		labelComposite.setLayout(new GridLayout(1, false));
@@ -118,7 +103,69 @@ public class BashEditorSaveActionsPreferencePage extends FieldEditorPreferencePa
 					 + "opened file. External tool should overwrite the given filename\n"
 					 + "with the reformatted document.");
 
+		// NOTE: we set grid data for the Validate Button so that it has an horizontal span = 2 and thus takes entire last row
+		validateBtn = new Button(externalToolGroup, SWT.PUSH);
+		validateBtn.setText("Validate external tool");
+		validateBtn.addSelectionListener(widgetSelectedAdapter(e -> doValidateExternalTool()));
+		GridData validateBtnGridData = new GridData();
+		validateBtnGridData.horizontalAlignment = GridData.CENTER;
+		validateBtnGridData.horizontalSpan = 2;
+		validateBtn.setLayoutData(validateBtnGridData);
+		
 		enableSaveActionFieldEditors(isSaveActionEnabled());
+	}
+
+	protected File writeDocumentInTempFile() throws IOException {
+		File tempFile;
+		tempFile = File.createTempFile("eclipse-basheditor", ".tmp");
+
+		// put the current contents in the temp file
+		FileWriter fw = new FileWriter(tempFile);
+		fw.write("function test() {\necho dummy;\n}\n");
+		fw.close();
+
+		return tempFile;
+	}
+	
+	protected void doValidateExternalTool() {
+		String externalToolString = saveActionExternalSourceFormatterArguments.getStringValue();
+
+		File dummyTmpFile;
+		try {
+			dummyTmpFile = writeDocumentInTempFile();
+		} catch (IOException e) {
+			MessageDialog.openError(getShell(), "Validation Results", "Failed creating a temporary file for validation purposes.");
+			return;
+		}
+		
+		BashEditorFileProcessContext processContext = new BashEditorFileProcessContext(dummyTmpFile);
+
+		// substitute in the external tool cmd line the special placeholders:
+		String[] cmd_args = commandArrayBuilder.build(externalToolString, dummyTmpFile);
+		if (commandArrayBuilder.getNumKeywordsReplaced() == 0) {
+			MessageDialog.openError(getShell(), "Validation Results", "The command line is not including the special placeholder $filename.");
+			return;
+		}
+
+		OutputHandler.STRING_OUTPUT.clearOutput();
+		SimpleProcessExecutor executor = new SimpleProcessExecutor(OutputHandler.STRING_OUTPUT, true, true, 10);
+
+		int exitCode;
+		try {
+			exitCode = executor.execute(processContext, processContext, processContext, cmd_args);
+		} catch (IOException e) {
+			MessageDialog.openError(getShell(), "Validation Results", "Validation of external tool command line '"
+					+ externalToolString + "': " + e.getMessage());
+			return;
+		}
+		
+		if (exitCode == 0) {
+			MessageDialog.openInformation(getShell(), "Validation Results", "Successfully validated external tool command line.");
+		} else {
+			MessageDialog.openError(getShell(), "Validation Results", "Validation of external tool command line '"
+					+ externalToolString + "' failed with exit code " + exitCode + ": \" "
+					+ OutputHandler.STRING_OUTPUT.getFullOutput() + "\"");
+		}
 	}
 
 	public boolean isSaveActionEnabled() {
@@ -126,10 +173,10 @@ public class BashEditorSaveActionsPreferencePage extends FieldEditorPreferencePa
 	}
 	
 	public void enableSaveActionFieldEditors(boolean enable) {
-		saveActionExternalSourceFormatter.getTextControl(fileComposite).setEnabled(enable);
-		saveActionExternalSourceFormatter.getChangeControl(fileComposite).setEnabled(enable);
+		validateBtn.setEnabled(enable);
 		saveActionExternalSourceFormatterArguments.getTextControl(externalToolGroup).setEnabled(enable);
 	}
+	
 	
 	@Override
 	public void propertyChange(PropertyChangeEvent event) {

--- a/basheditor-plugin/src/main/java-eclipse/de/jcup/basheditor/preferences/BashEditorSaveActionsPreferencePage.java
+++ b/basheditor-plugin/src/main/java-eclipse/de/jcup/basheditor/preferences/BashEditorSaveActionsPreferencePage.java
@@ -15,12 +15,13 @@ package de.jcup.basheditor.preferences;
  *
  */
 
-import static de.jcup.basheditor.preferences.BashEditorPreferenceConstants.P_SAVE_ACTION_EXTERNAL_TOOL_ENABLED;
 import static de.jcup.basheditor.preferences.BashEditorPreferenceConstants.P_SAVE_ACTION_EXTERNAL_TOOL_COMMAND;
+import static de.jcup.basheditor.preferences.BashEditorPreferenceConstants.P_SAVE_ACTION_EXTERNAL_TOOL_ENABLED;
 
 import org.eclipse.jface.preference.BooleanFieldEditor;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
 import org.eclipse.jface.preference.StringFieldEditor;
+import org.eclipse.jface.util.PropertyChangeEvent;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
@@ -34,6 +35,7 @@ import de.jcup.basheditor.BashEditorUtil;
 public class BashEditorSaveActionsPreferencePage extends FieldEditorPreferencePage implements IWorkbenchPreferencePage {
 	private BooleanFieldEditor saveActionExternalSourceFormatterEnabled;
 	private StringFieldEditor saveActionFieldEditor;
+	private Group externalToolGroup;
 	
 	public BashEditorSaveActionsPreferencePage() {
 		super(GRID);
@@ -56,7 +58,7 @@ public class BashEditorSaveActionsPreferencePage extends FieldEditorPreferencePa
 		externalToolsGroupLayoutData.horizontalSpan = 2;
 		externalToolsGroupLayoutData.widthHint = 400;
 
-		Group externalToolGroup = new Group(getFieldEditorParent(), SWT.NONE);
+		externalToolGroup = new Group(getFieldEditorParent(), SWT.NONE);
 		externalToolGroup.setText("External tool");
 		externalToolGroup.setLayout(new GridLayout());
 		externalToolGroup.setLayoutData(externalToolsGroupLayoutData);
@@ -78,6 +80,22 @@ public class BashEditorSaveActionsPreferencePage extends FieldEditorPreferencePa
 		createNoteComposite(labelGroup.getFont(), labelGroup, 
 			"Note:", "Special $filename placeholder can be used to indicate currently\n"
 					 + "opened file. External tool output will replace current document.");
+
+		enableSaveActionFieldEditor(isSaveActionEnabled());
 	}
 
+	public boolean isSaveActionEnabled() {
+		return saveActionExternalSourceFormatterEnabled.getBooleanValue();
+	}
+	
+	public void enableSaveActionFieldEditor(boolean enable) {
+		saveActionFieldEditor.getTextControl(externalToolGroup).setEnabled(enable);
+	}
+	
+	@Override
+	public void propertyChange(PropertyChangeEvent event) {
+		// if saveAction checkbock is unchecked, disable the text editor to make it clear to the user
+		// that the 2 are connected:
+		enableSaveActionFieldEditor(isSaveActionEnabled());
+	}
 }

--- a/basheditor-plugin/src/main/java-eclipse/de/jcup/basheditor/preferences/BashEditorSaveActionsPreferencePage.java
+++ b/basheditor-plugin/src/main/java-eclipse/de/jcup/basheditor/preferences/BashEditorSaveActionsPreferencePage.java
@@ -17,14 +17,17 @@ package de.jcup.basheditor.preferences;
 
 import static de.jcup.basheditor.preferences.BashEditorPreferenceConstants.P_SAVE_ACTION_EXTERNAL_TOOL_COMMAND;
 import static de.jcup.basheditor.preferences.BashEditorPreferenceConstants.P_SAVE_ACTION_EXTERNAL_TOOL_ENABLED;
+import static de.jcup.basheditor.preferences.BashEditorPreferenceConstants.P_SAVE_ACTION_EXTERNAL_TOOL_ARGUMENTS;
 
 import org.eclipse.jface.preference.BooleanFieldEditor;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
+import org.eclipse.jface.preference.FileFieldEditor;
 import org.eclipse.jface.preference.StringFieldEditor;
 import org.eclipse.jface.util.PropertyChangeEvent;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Group;
 import org.eclipse.ui.IWorkbench;
@@ -34,8 +37,26 @@ import de.jcup.basheditor.BashEditorUtil;
 
 public class BashEditorSaveActionsPreferencePage extends FieldEditorPreferencePage implements IWorkbenchPreferencePage {
 	private BooleanFieldEditor saveActionExternalSourceFormatterEnabled;
-	private StringFieldEditor saveActionFieldEditor;
+	private MyFileEditor saveActionExternalSourceFormatter;
+	private StringFieldEditor saveActionExternalSourceFormatterArguments;
+	
+	// UI
+	private Composite fileComposite;
 	private Group externalToolGroup;
+	
+	// dummy class just to override the FileFieldEditor::getChangeControl() visibility:
+	class MyFileEditor extends FileFieldEditor {
+		public MyFileEditor(String name, String labelText, Composite parent) {
+			super(name, labelText, parent);
+		}
+
+		@Override
+		public Button getChangeControl(Composite parent) {
+			return super.getChangeControl(parent);
+		}
+	}
+
+	
 	
 	public BashEditorSaveActionsPreferencePage() {
 		super(GRID);
@@ -55,47 +76,70 @@ public class BashEditorSaveActionsPreferencePage extends FieldEditorPreferencePa
 		/* --------------------- */
 
 		GridData externalToolsGroupLayoutData = new GridData(GridData.HORIZONTAL_ALIGN_FILL|GridData.GRAB_HORIZONTAL);
-		externalToolsGroupLayoutData.horizontalSpan = 2;
-		externalToolsGroupLayoutData.widthHint = 400;
+		//externalToolsGroupLayoutData.horizontalSpan = 1;
+		//externalToolsGroupLayoutData.widthHint = 400;
 
 		externalToolGroup = new Group(getFieldEditorParent(), SWT.NONE);
-		externalToolGroup.setText("External tool");
-		externalToolGroup.setLayout(new GridLayout());
+		externalToolGroup.setText("External source reformatter");
+		externalToolGroup.setLayout(new GridLayout(2, false));   // create a 2-column based GRID
 		externalToolGroup.setLayoutData(externalToolsGroupLayoutData);
-		
+
+		// NOTE: the BooleanFieldEditor() has an horizontalSpan = 2, so will take the entire first row of grid
 		saveActionExternalSourceFormatterEnabled = new BooleanFieldEditor(P_SAVE_ACTION_EXTERNAL_TOOL_ENABLED.getId(),
 				"Execute command on save", externalToolGroup);
-		saveActionExternalSourceFormatterEnabled.getDescriptionControl(externalToolGroup).setToolTipText("External program to run every time a script file is saved; its output will replace current document.");
+		saveActionExternalSourceFormatterEnabled.getDescriptionControl(externalToolGroup).
+			setToolTipText("External program to run every time a script file is saved; its output will replace current document.");
 		addField(saveActionExternalSourceFormatterEnabled);
 
-		saveActionFieldEditor = new StringFieldEditor(P_SAVE_ACTION_EXTERNAL_TOOL_COMMAND.getId(), "Command:", 
-				StringFieldEditor.UNLIMITED, StringFieldEditor.VALIDATE_ON_FOCUS_LOST, externalToolGroup);
-		addField(saveActionFieldEditor);
+		// NOTE: we create a Composite in which we place the FileFieldEditor() and set an horizontalSpan = 2, so will take the entire second row of grid 
+		fileComposite = new Composite(externalToolGroup, SWT.NONE);
+		fileComposite.setLayout(new GridLayout(1, false));
+		GridData fileLayoutData = new GridData(GridData.HORIZONTAL_ALIGN_FILL|GridData.GRAB_HORIZONTAL);
+		fileLayoutData.horizontalSpan = 2;
+		fileComposite.setLayoutData(fileLayoutData);
+		saveActionExternalSourceFormatter = 
+				new MyFileEditor(P_SAVE_ACTION_EXTERNAL_TOOL_COMMAND.getId(), "External tool", fileComposite);
+		addField(saveActionExternalSourceFormatter);
+		
+		// NOTE: the StringFieldEditor() has an horizontal span = 2, so will take the entire third row of grid
+		saveActionExternalSourceFormatterArguments = 
+				new StringFieldEditor(P_SAVE_ACTION_EXTERNAL_TOOL_ARGUMENTS.getId(), "External tool command-line arguments:", 
+						StringFieldEditor.UNLIMITED, StringFieldEditor.VALIDATE_ON_FOCUS_LOST, externalToolGroup);
+		addField(saveActionExternalSourceFormatterArguments);
 
-		Composite labelGroup = new Composite(externalToolGroup, SWT.NONE);
-		labelGroup.setLayout(new GridLayout());
+		// NOTE: we create a Composite in which we place the note fields and set an horizontalSpan = 2, so will take the entire last row of grid
+		Composite labelComposite = new Composite(externalToolGroup, SWT.NONE);
+		labelComposite.setLayout(new GridLayout(1, false));
 		GridData labelGroupLayoutData = new GridData(GridData.HORIZONTAL_ALIGN_FILL|GridData.GRAB_HORIZONTAL);
 		labelGroupLayoutData.horizontalSpan = 2;
-		labelGroup.setLayoutData(labelGroupLayoutData);
-		createNoteComposite(labelGroup.getFont(), labelGroup, 
+		labelComposite.setLayoutData(labelGroupLayoutData);
+		createNoteComposite(labelComposite.getFont(), labelComposite, 
 			"Note:", "Special $filename placeholder can be used to indicate currently\n"
-					 + "opened file. External tool output will replace current document.");
+					 + "opened file. External tool should overwrite the given filename\n"
+					 + "with the reformatted document.");
 
-		enableSaveActionFieldEditor(isSaveActionEnabled());
+		enableSaveActionFieldEditors(isSaveActionEnabled());
 	}
 
 	public boolean isSaveActionEnabled() {
 		return saveActionExternalSourceFormatterEnabled.getBooleanValue();
 	}
 	
-	public void enableSaveActionFieldEditor(boolean enable) {
-		saveActionFieldEditor.getTextControl(externalToolGroup).setEnabled(enable);
+	public void enableSaveActionFieldEditors(boolean enable) {
+		saveActionExternalSourceFormatter.getTextControl(fileComposite).setEnabled(enable);
+		saveActionExternalSourceFormatter.getChangeControl(fileComposite).setEnabled(enable);
+		saveActionExternalSourceFormatterArguments.getTextControl(externalToolGroup).setEnabled(enable);
 	}
 	
 	@Override
 	public void propertyChange(PropertyChangeEvent event) {
-		// if saveAction checkbock is unchecked, disable the text editor to make it clear to the user
-		// that the 2 are connected:
-		enableSaveActionFieldEditor(isSaveActionEnabled());
+		// if saveAction checkbock is unchecked, disable other controls to make it clear they are logically connected together:
+		enableSaveActionFieldEditors(isSaveActionEnabled());
+	}
+
+	@Override
+	protected void initialize() {
+		super.initialize();
+		enableSaveActionFieldEditors(isSaveActionEnabled());
 	}
 }

--- a/basheditor-plugin/src/main/java/de/jcup/basheditor/ExternalToolCommandArrayBuilder.java
+++ b/basheditor-plugin/src/main/java/de/jcup/basheditor/ExternalToolCommandArrayBuilder.java
@@ -3,15 +3,25 @@ package de.jcup.basheditor;
 import java.io.File;
 
 public class ExternalToolCommandArrayBuilder {
+	
+	private int numKeywordsReplaced = 0;
 
 	public String[] build(String externalToolCall, File editorFile) {
+		numKeywordsReplaced = 0;
 		String[] ret = externalToolCall.split(" ");
 		
 		// detect special placeholder(s):
 		for (int i=0; i < ret.length; i++)
 			if (ret[i].equalsIgnoreCase("$filename"))
+			{
 				ret[i] = editorFile.toPath().toString();
+				numKeywordsReplaced++;
+			}
 		
 		return ret;
+	}
+
+	public int getNumKeywordsReplaced() {
+		return numKeywordsReplaced;
 	}
 }

--- a/basheditor-plugin/src/main/java/de/jcup/basheditor/process/OutputHandler.java
+++ b/basheditor-plugin/src/main/java/de/jcup/basheditor/process/OutputHandler.java
@@ -52,6 +52,10 @@ public interface OutputHandler {
 		public String getFullOutput() {
 			return fullOutput;
 		}
+		
+		public void clearOutput() {
+			fullOutput = "";
+		}
 	}
 
 }


### PR DESCRIPTION
This PR adds a few things for feature #117:

BashEditor:
- Add external tool stderr collection. This is useful specially when you have wrong syntax in the bash file and beautysh will fail with indent/outdent error. Previously it would just say "exited with exit code 1".
Try to write e.g. 
for test in 1 2 3 ; doWithTypo 
 echo ciao ; 
done

BashEditor:
-  Clear output coming from previous runs of external tool.

SaveActionPreferencePage:
- Use a FileFieldEditor to get automatic validation of the existence of the external tool.
- Add enable/disable of controls based on checkbox value.
