### PR TITLE
Debug termination improved #194

### DIFF
--- a/basheditor-plugin/src/main/java-eclipse/de/jcup/basheditor/debug/element/BashDebugTarget.java
+++ b/basheditor-plugin/src/main/java-eclipse/de/jcup/basheditor/debug/element/BashDebugTarget.java
@@ -84,6 +84,8 @@ public class BashDebugTarget extends AbstractBashDebugElement implements IDebugT
 	private IFile fileResource;
 	
 	private BashDocumentChangeRegistry documentChangeRegistry;
+
+	private boolean terminated;
 	
 	public BashDebugTarget(ILaunch launch, IProcess process, int port, IFile programFileResource) throws CoreException {
 		super(null);
@@ -185,15 +187,23 @@ public class BashDebugTarget extends AbstractBashDebugElement implements IDebugT
 	}
 
 	public boolean canTerminate() {
-		return getProcess().canTerminate();
+		return !isTerminated();
 	}
 
 	public boolean isTerminated() {
-		return getProcess().isTerminated();
+		return terminated;
 	}
 
 	public void terminate() throws DebugException {
+		if (terminated) {
+			return;
+		}
+		terminated=true;
 		debugger.sendCommand(DebugCommand.TERMINATE);
+		for (IThread t: threads) {
+			t.terminate();
+		}
+		launch.terminate();
 	}
 
 	public boolean canResume() {

--- a/basheditor-plugin/src/main/java-eclipse/de/jcup/basheditor/debug/element/BashThread.java
+++ b/basheditor-plugin/src/main/java-eclipse/de/jcup/basheditor/debug/element/BashThread.java
@@ -34,6 +34,8 @@ public class BashThread extends AbstractBashDebugElement implements IThread, Deb
 	 */
 	private boolean stepping = false;
 
+	private boolean terminated;
+
 	/**
 	 * Constructs a new thread for the given target
 	 * 
@@ -142,10 +144,14 @@ public class BashThread extends AbstractBashDebugElement implements IThread, Deb
 	}
 
 	public boolean isTerminated() {
-		return getDebugTarget().isTerminated();
+		return terminated;
 	}
 
 	public void terminate() throws DebugException {
+		if (terminated) {
+			return;
+		}
+		terminated = true;
 		getDebugTarget().terminate();
 	}
 

--- a/basheditor-plugin/src/main/java-eclipse/de/jcup/basheditor/debug/element/FallbackBashDebugTarget.java
+++ b/basheditor-plugin/src/main/java-eclipse/de/jcup/basheditor/debug/element/FallbackBashDebugTarget.java
@@ -45,7 +45,7 @@ public class FallbackBashDebugTarget implements IDebugTarget, DebugEventSource {
 
 	public FallbackBashDebugTarget(ILaunch launch, String name) {
 	    this.launch=launch;
-	    this.process = new BashRemoteProcess(launch);
+	    this.process = new BashRemoteProcess(launch,null);
 	    this.name=name;
 	}
 	

--- a/basheditor-plugin/src/main/java-eclipse/de/jcup/basheditor/debug/launch/BashRemoteProcess.java
+++ b/basheditor-plugin/src/main/java-eclipse/de/jcup/basheditor/debug/launch/BashRemoteProcess.java
@@ -24,9 +24,11 @@ public class BashRemoteProcess implements IProcess {
 	public boolean terminated = false;
     private ILaunch launch;
     private int exitValue = -1;
+	private Process terminalProcess;
 	
-	public BashRemoteProcess(ILaunch launch) {
+	public BashRemoteProcess(ILaunch launch, Process terminalProcess) {
 	    this.launch=launch;
+	    this.terminalProcess=terminalProcess;
 	}
 
 	public synchronized boolean isTerminated() {
@@ -42,8 +44,17 @@ public class BashRemoteProcess implements IProcess {
 	}
 
 	public void terminate() throws DebugException {
+		if (terminated) {
+			return;
+		}
 		terminated = true;
-
+		launch.terminate();
+		
+		if (terminalProcess!=null) {
+			if (terminalProcess.isAlive()) {
+				terminalProcess.destroyForcibly();
+			}
+		}
 	}
 
 	public String getLabel() {


### PR DESCRIPTION
- termination of debug elements does now always terminate complete
  launch and so all children
- remote process termination will now terminate the terminal process
  and so terminal window