### PR TITLE
Force plug-in activation for custom property testers

### DIFF
--- a/basheditor-plugin/plugin.xml
+++ b/basheditor-plugin/plugin.xml
@@ -117,7 +117,7 @@
 				         				<count value="1"/>
 	                                    <iterate ifEmpty="false">
 	                                    	 <adapt type="org.eclipse.core.resources.IFile">
-			         							<test property="de.jcup.basheditor.isBashFileWithoutExtension" value="true"/>
+			         							<test property="de.jcup.basheditor.isBashFileWithoutExtension" value="true" forcePluginActivation="true"/>
 				         					</adapt>
 				         				</iterate>
                               </with>
@@ -138,7 +138,7 @@
 	                                    <iterate ifEmpty="false">
 	                                    	 <adapt type="org.eclipse.core.resources.IFile">
 	                                    	  <or>
-			         							<test property="de.jcup.basheditor.isBashFileWithoutExtension" value="true"/>
+			         							<test property="de.jcup.basheditor.isBashFileWithoutExtension" value="true" forcePluginActivation="true"/>
 			         							<test property="org.eclipse.core.resources.extension" value="sh" />
 			         						  </or>
 				         					</adapt>
@@ -160,7 +160,7 @@
 				         				<count value="1"/>
 	                                    <iterate ifEmpty="false">
 	                                    	 <adapt type="org.eclipse.core.resources.IResource">
-	                                    	     <test property="de.jcup.basheditor.isOpenPathActionEnabled" value="true"/>
+	                                    	     <test property="de.jcup.basheditor.isOpenPathActionEnabled" value="true" forcePluginActivation="true"/>
 				         					 </adapt>
 				         				</iterate>
                               </with>
@@ -890,7 +890,7 @@ fi</pattern>
 				                         value="*.sh"/>
 				            </adapt>
 				        	<adapt type="org.eclipse.core.resources.IFile">
-								<test property="de.jcup.basheditor.isBashFileWithoutExtension" value="true"/>
+								<test property="de.jcup.basheditor.isBashFileWithoutExtension" value="true" forcePluginActivation="true"/>
 				            </adapt>
 				     </or>
 			        </iterate>


### PR DESCRIPTION
This change ensures Eclipse correctly uses the property testers `isBashFileWithoutExtension` and `isOpenPathActionEnabled`, by setting the `forcePluginActivation` property in the respective `plugin.xml` entries. This allows Eclipse to load the property tester class prior to trying to use it - in case the bash editor plug-in was not activated yet.

Fixes: #275